### PR TITLE
Prevent excessive journal logging by wakeup signal

### DIFF
--- a/ikvm_input.cpp
+++ b/ikvm_input.cpp
@@ -197,12 +197,7 @@ void Input::sendWakeupPacket()
         memcpy(&wakeupReport[1], &xy, 2);
         memcpy(&wakeupReport[3], &xy, 2);
 
-        if (write(pointerFd, wakeupReport, PTR_REPORT_LENGTH) !=
-            PTR_REPORT_LENGTH)
-        {
-            log<level::ERR>("Failed to write pointer report",
-                            entry("ERROR=%s", strerror(errno)));
-        }
+        writePointer(wakeupReport);
     }
 
     if (keyboardFd >= 0)
@@ -211,22 +206,14 @@ void Input::sendWakeupPacket()
 
         wakeupReport[0] = keyToMod(XK_Shift_L);
 
-        if (write(keyboardFd, wakeupReport, KEY_REPORT_LENGTH) !=
-            KEY_REPORT_LENGTH)
+        if (!writeKeyboard(wakeupReport))
         {
-            log<level::ERR>("Failed to write keyboard report",
-                            entry("ERROR=%s", strerror(errno)));
             return;
         }
 
         wakeupReport[0] = 0;
 
-        if (write(keyboardFd, wakeupReport, KEY_REPORT_LENGTH) !=
-            KEY_REPORT_LENGTH)
-        {
-            log<level::ERR>("Failed to write keyboard report",
-                            entry("ERROR=%s", strerror(errno)));
-        }
+        writeKeyboard(wakeupReport);
     }
 }
 
@@ -234,44 +221,14 @@ void Input::sendReport()
 {
     if (sendKeyboard && keyboardFd >= 0)
     {
-        if (write(keyboardFd, keyboardReport, KEY_REPORT_LENGTH) !=
-            KEY_REPORT_LENGTH)
-        {
-            log<level::ERR>("Failed to write keyboard report",
-                            entry("ERROR=%s", strerror(errno)));
-
-            if (errno == ESHUTDOWN)
-            {
-                close(keyboardFd);
-                keyboardFd = -1;
-            }
-        }
+        writeKeyboard(keyboardReport);
 
         sendKeyboard = false;
     }
 
     if (sendPointer && pointerFd >= 0)
     {
-        if (write(pointerFd, pointerReport, PTR_REPORT_LENGTH) !=
-            PTR_REPORT_LENGTH)
-        {
-            if (!pointerError)
-            {
-                log<level::ERR>("Failed to write pointer report",
-                                entry("ERROR=%s", strerror(errno)));
-                pointerError = true;
-            }
-
-            if (errno == ESHUTDOWN)
-            {
-                close(pointerFd);
-                pointerFd = -1;
-            }
-        }
-        else
-        {
-            pointerError = false;
-        }
+        writePointer(pointerReport);
 
         sendPointer = false;
     }
@@ -452,6 +409,48 @@ uint8_t Input::keyToScancode(rfbKeySym key)
     }
 
     return scancode;
+}
+
+bool Input::writeKeyboard(const uint8_t *report)
+{
+    if (write(keyboardFd, report, KEY_REPORT_LENGTH) != KEY_REPORT_LENGTH)
+    {
+        log<level::ERR>("Failed to write keyboard report",
+                        entry("ERROR=%s", strerror(errno)));
+
+        if (errno == ESHUTDOWN)
+        {
+            close(keyboardFd);
+            keyboardFd = -1;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+void Input::writePointer(const uint8_t *report)
+{
+    if (write(pointerFd, report, PTR_REPORT_LENGTH) != PTR_REPORT_LENGTH)
+    {
+        if (!pointerError)
+        {
+            log<level::ERR>("Failed to write pointer report",
+                            entry("ERROR=%s", strerror(errno)));
+            pointerError = true;
+        }
+
+        if (errno == ESHUTDOWN)
+        {
+            close(pointerFd);
+            pointerFd = -1;
+        }
+    }
+    else
+    {
+        pointerError = false;
+    }
 }
 
 } // namespace ikvm

--- a/ikvm_input.hpp
+++ b/ikvm_input.hpp
@@ -87,6 +87,9 @@ class Input
      */
     static uint8_t keyToScancode(rfbKeySym key);
 
+    bool writeKeyboard(const uint8_t *report);
+    void writePointer(const uint8_t *report);
+
     /* @brief Indicates whether or not a pointer report error has occurred */
     bool pointerError;
     /* @brief Indicates whether or not to send a keyboard report */


### PR DESCRIPTION
When the application is waiting for timings, it restarts the video to
try and get a signal. Part of this process sends a wake-up signal on
the virtual keyboard and pointer in case host VGA has slept. But if the
host is shut down, this causes repeated errors in the journal as the
HID gadgets return errors.

Fix this by consolidating the keyboard/pointer write functions and
therefore closing the HID gadget file handles when the host is shut
down, preventing further wake-up attempts until host returns.

Change-Id: Id5fe484c976eccefa6a72393d4d6b2b301d28a1a
Signed-off-by: Eddie James <eajames@linux.ibm.com>